### PR TITLE
Add OSX Aliases

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -15,6 +15,12 @@ then
 
         # OSX version of which doesn't support as many options as Linux
         alias which='/usr/bin/which -a'
+
+        alias openTcpPorts='sudo lsof -i -n -P | \grep TCP'
+        alias openUdpPorts='sudo lsof -i -n -P | \grep UDP'
+        alias listenTcpPort='sudo lsof -iTCP -sTCP:LISTEN -n -P'
+        alias osxDNS='scutil --dns'
+        alias osxRoutes='netstat -nr'
     fi
 # Solaris
 elif [ ${osType} == "SunOS" ]
@@ -47,3 +53,5 @@ alias svncolor='python ~/bin/svn-color.py'
 alias svnc='python ~/bin/svn-color.py'
 alias csvn='python ~/bin/svn-color.py'
 
+# Public git repo thats kind of private via obfuscating
+alias beauhoyt_sha2='echo -n $(echo -n beauhoyt | shasum -a 256 | cut -c 1-39)'

--- a/.bash_exports
+++ b/.bash_exports
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 # Xterm support
 if [ -n "${DISPLAY}" -a "${TERM}" = "xterm" ]
 then
@@ -10,16 +11,23 @@ then
     export TERM="xterm"
 fi
 
-# MacVim
-if [ -d "/Applications" ]
-then
-    export VIM_APP_DIR="/Applications"
-fi
-
-# GO lang
+# GO lang path
 export GOPATH="${HOME}/go"
+
 if [ ${osType} == "Darwin" ]
 then
+    # Homebrew Github API Token for higher ratelimit on brew commands
+    if [ -e "${HOME}/.bash_exports_homebrew_github_api_token" ]
+    then
+        source ${HOME}/.bash_exports_homebrew_github_api_token
+    fi
+
+    # MacVim
+    if [ -d "/Applications" ]
+    then
+        export VIM_APP_DIR="/Applications"
+    fi
+
     export PATH="${PATH}:${GOPATH}/bin:/usr/local/opt/go/libexec/bin"
 else
     export PATH="${PATH}:${GOPATH}/bin:/usr/local/go/bin"


### PR DESCRIPTION
Added Aliases:
- openTcpPorts='sudo lsof -i -n -P | \grep TCP'
- openUdpPorts='sudo lsof -i -n -P | \grep UDP'
- listenTcpPort='sudo lsof -iTCP -sTCP:LISTEN -n -P'
- osxDNS='scutil --dns'
- osxRoutes='netstat -nr'

Added export for homebrew to use personal GITHUB API key

Cleaned up some MacVim stuff
