### PR TITLE
Update Bash Aliases for OSX (aka macOS... lol)

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -16,11 +16,28 @@ then
         # OSX version of which doesn't support as many options as Linux
         alias which='/usr/bin/which -a'
 
+        # OSX alias helpers similar to linux netstat tool
         alias openTcpPorts='sudo lsof -i -n -P | \grep TCP'
         alias openUdpPorts='sudo lsof -i -n -P | \grep UDP'
         alias listenTcpPort='sudo lsof -iTCP -sTCP:LISTEN -n -P'
         alias osxDNS='scutil --dns'
         alias osxRoutes='netstat -nr'
+
+        # OSX toggle Hidden files in Finder, because it's no longer an option
+        # inside Finder Preferences.
+        alias toggleHiddenFiles='case "$(/usr/bin/defaults read com.apple.finder AppleShowAllFiles)" in
+            NO)
+                /usr/bin/defaults write com.apple.finder AppleShowAllFiles YES &&
+                /bin/echo "Hidden Files Will Show In Finder"
+                ;;
+            YES)
+                /usr/bin/defaults write com.apple.finder AppleShowAllFiles NO &&
+                /bin/echo "Hidden Files Will NOT Show In Finder"
+                ;;
+            *)
+                /bin/echo "Error: invalid response: $(/usr/bin/defaults read com.apple.finder AppleShowAllFiles)"
+                ;;
+        esac'
     fi
 # Solaris
 elif [ ${osType} == "SunOS" ]

--- a/.vimrc
+++ b/.vimrc
@@ -224,6 +224,34 @@ map <C-m> :lp<CR>
 " let g:syntastic_go_checkers = ['golint', 'govet', 'errcheck']
 " let g:syntastic_mode_map = { 'mode': 'active', 'passive_filetypes': ['go'] }
 
+" let g:tagbar_type_go = {
+"     \ 'ctagstype' : 'go',
+"     \ 'kinds'     : [
+"         \ 'p:package',
+"         \ 'i:imports:1',
+"         \ 'c:constants',
+"         \ 'v:variables',
+"         \ 't:types',
+"         \ 'n:interfaces',
+"         \ 'w:fields',
+"         \ 'e:embedded',
+"         \ 'm:methods',
+"         \ 'r:constructor',
+"         \ 'f:functions'
+"     \ ],
+"     \ 'sro' : '.',
+"     \ 'kind2scope' : {
+"         \ 't' : 'ctype',
+"         \ 'n' : 'ntype'
+"     \ },
+"     \ 'scope2kind' : {
+"         \ 'ctype' : 't',
+"         \ 'ntype' : 'n'
+"     \ },
+"     \ 'ctagsbin'  : 'gotags',
+"     \ 'ctagsargs' : '-sort -silent'
+" \ }
+
 " ============================================================================
 " Python IDE Setup
 " ============================================================================
@@ -245,20 +273,20 @@ map <Leader>b Oimport ipdb; ipdb.set_trace() # BREAKPOINT<C-c>
 " See http://stackoverflow.com/questions/2170023/how-to-map-keys-for-popup-menu-in-vim
 " j will map to ctrl+N
 " k will map to ctrl+P
-set completeopt=longest,menuone
-function! OmniPopup(action)
-    if pumvisible()
-        if a:action == 'j'
-            return "\<C-N>"
-        elseif a:action == 'k'
-            return "\<C-P>"
-        endif
-    endif
-    return a:action
-endfunction
-
-inoremap <silent><C-j> <C-R>=OmniPopup('j')<CR>
-inoremap <silent><C-k> <C-R>=OmniPopup('k')<CR>
+" set completeopt=longest,menuone
+" function! OmniPopup(action)
+"     if pumvisible()
+"         if a:action == 'j'
+"             return "\<C-N>"
+"         elseif a:action == 'k'
+"             return "\<C-P>"
+"         endif
+"     endif
+"     return a:action
+" endfunction
+"
+" inoremap <silent><C-j> <C-R>=OmniPopup('j')<CR>
+" inoremap <silent><C-k> <C-R>=OmniPopup('k')<CR>
 
 " Python folding
 " mkdir -p ~/.vim/ftplugin


### PR DESCRIPTION
- Added alias to toggle between seeing hidden files in finder on OSX (macOS)
- Removed some gotagbar configs in vimrc, because the latest version of vim-go
  seems to be more better.
- Removed some Python IDE configuration in the vimrc that was just slowing
  python parsing down and really not adding much functionality to the IDE
  itself
