### PR TITLE
Add Linux Support SSH Agent and SSH Add

### DIFF
--- a/.bash_ssh_agent
+++ b/.bash_ssh_agent
@@ -5,15 +5,27 @@
 # File to hold existing SSH agent sesssion
 SSH_ENV="${HOME}/.ssh/environment"
 
+SSH_AGENT_BIN="/usr/bin/ssh-agent"
+SSH_ADD_BIN="/usr/bin/ssh-add"
+
+if [ -e "/usr/local/bin/ssh-agent" ]
+then
+  SSH_AGENT_BIN="/usr/local/bin/ssh-agent"
+fi
+if [ -e "/usr/local/bin/ssh-add" ]
+then
+  SSH_ADD_BIN="/usr/local/bin/ssh-add"
+fi
+
 function start_ssh_agent {
   echo "Initializing new SSH agent..."
-  /usr/local/bin/ssh-agent -s | sed 's/^echo/#echo/' > "${SSH_ENV}"
+  $SSH_AGENT_BIN -s | sed 's/^echo/#echo/' > "${SSH_ENV}"
   chmod 0600 "${SSH_ENV}"
   source "${SSH_ENV}" > /dev/null
   echo "DONE Initializing..."
 
   echo "Adding Keys..."
-  /usr/local/bin/ssh-add
+  $SSH_ADD_BIN
 }
 
 osType=$(uname)
@@ -21,9 +33,7 @@ osType=$(uname)
 # Handle for only OSX (Darwin) for now. This should only be called if it's a
 # TTY; not PTS (pseudo TTY) or STY (pseudo screen TTY). Meaning it can't be a
 # SSH session; it has to be a physical login.
-#
-# TODO: Might add Linux OS type for fedora/ubuntu desktop/laptops.
-if [ -z "${SSH_TTY}" -a $osType == "Darwin" ]
+if [ -z "${SSH_TTY}" ] && [ $osType == "Darwin" -o $osType == "Linux" ]
 then
 
   # Recover existing SSH agent session
@@ -32,7 +42,7 @@ then
     source "${SSH_ENV}" > /dev/null
 
     # Restart SSH agent if it has crashed
-    ps -ef | grep ${SSH_AGENT_PID} | grep ssh-agent > /dev/null || {
+    ps -ef | grep "${SSH_AGENT_PID}" | grep "ssh-agent" > /dev/null || {
       start_ssh_agent
     }
 


### PR DESCRIPTION
Added linux support for:
- ssh-agent
- ssh-add
- Check if these binaries on OSX are in the /usr/local/bin/ instead of the
  /usr/bin/ folder as they normally are in Linux. I believe OSX brew uses the
  latter.
