### PR TITLE
Update .bashrc to fix Darwin Auto Complete

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -23,13 +23,20 @@ unset i
 # this, if it's already enabled in /etc/bash.bashrc and /etc/profile
 # sources /etc/bash.bashrc).
 if [ `uname` = 'Darwin' ]; then
-    if [ -f `brew --prefix`/etc/bash_completion ]; then
-        source `brew --prefix`/etc/bash_completion
-    fi
-    if [ -d `brew --prefix`/etc/bash_completion.d ]; then
-        for i in $(ls -1 `brew --prefix`/etc/bash_completion.d); do
-            source `brew --prefix`/etc/bash_completion.d/${i}
-        done
+    # This code chuck might not be needed anymore with:
+    #  brew install bash-completion
+    # if [ -f `brew --prefix`/etc/bash_completion ]; then
+    #     source `brew --prefix`/etc/bash_completion
+    # fi
+    # if [ -d `brew --prefix`/etc/bash_completion.d ]; then
+    #     for i in $(ls -1 `brew --prefix`/etc/bash_completion.d); do
+    #         source `brew --prefix`/etc/bash_completion.d/${i}
+    #     done
+    # fi
+    # Run /usr/local/etc/profile.d/bash_completion.sh
+    if [ -r /usr/local/etc/profile.d/bash_completion.sh ]
+    then
+        source /usr/local/etc/profile.d/bash_completion.sh > /dev/null 2>&1
     fi
 else
     if [ -f /etc/bash_completion ] && ! shopt -oq posix; then


### PR DESCRIPTION
So what is being used now is the brew package bash-completion. They seem
to have fixed some loading issues that existed in the past. So now
finally updating this .bashrc to work correctly with those fixes.

NOTES:
[14:26:18][beau@Beaus-MacBook-Pro][fp-trunk-main](master)$ brew info bash-completion
bash-completion: stable 1.3 (bottled)
Programmable completion for Bash 3.2
https://salsa.debian.org/debian/bash-completion
Conflicts with:
  bash-completion@2 (because Differing version of same formula)
/usr/local/Cellar/bash-completion/1.3_3 (189 files, 608.2KB) *
  Poured from bottle on 2019-08-05 at 14:16:59
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/bash-completion.rb
==> Caveats
Add the following line to your ~/.bash_profile:
  [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"

Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
==> Analytics
install: 14,233 (30 days), 44,257 (90 days), 188,965 (365 days)
install_on_request: 12,942 (30 days), 40,156 (90 days), 172,969 (365 days)
build_error: 0 (30 days)